### PR TITLE
new dioxus_core api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dioxus-tui = { path = "./packages/tui", version = "^0.2.0", optional = true }
 dioxus-liveview = { path = "./packages/liveview", optional = true }
 
 dioxus-native-core = { path = "./packages/native-core", optional = true }
+dioxus-native-core-macro = { path = "./packages/native-core-macro", optional = true }
 
 # dioxus-mobile = { path = "./packages/mobile", version = "^0.2.0", optional = true }
 # dioxus-rsx = { path = "./packages/rsx", optional = true }
@@ -47,7 +48,7 @@ ayatana = ["dioxus-desktop/ayatana"]
 router = ["dioxus-router"]
 tui = ["dioxus-tui"]
 liveview = ["dioxus-liveview"]
-native-core = ["dioxus-native-core"]
+native-core = ["dioxus-native-core", "dioxus-native-core-macro"]
 
 
 [workspace]

--- a/packages/native-core-macro/Cargo.toml
+++ b/packages/native-core-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dioxus-native-core-macro"
+version = "0.2.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+syn = { version = "1.0.11", features = ["extra-traits"] }
+quote = "1.0"

--- a/packages/native-core-macro/src/lib.rs
+++ b/packages/native-core-macro/src/lib.rs
@@ -105,8 +105,8 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl State for #type_name{
-            fn update_node_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: Option<&'a dioxus_core::VElement<'a>>, ctx: &anymap::AnyMap) -> bool{
-                use dioxus_native_core::real_dom_new_api::NodeDepState as _;
+            fn update_node_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: &'a dioxus_core::VNode<'a>, ctx: &anymap::AnyMap) -> bool{
+                use dioxus_native_core::state::NodeDepState as _;
                 // println!("called update_node_dep_state with ty: {:?}", ty);
                 if false {
                     unreachable!();
@@ -117,8 +117,8 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                 }
             }
 
-            fn update_parent_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: Option<&'a dioxus_core::VElement<'a>>, parent: Option<&Self>, ctx: &anymap::AnyMap) -> bool{
-                use dioxus_native_core::real_dom_new_api::ParentDepState as _;
+            fn update_parent_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: &'a dioxus_core::VNode<'a>, parent: Option<&Self>, ctx: &anymap::AnyMap) -> bool{
+                use dioxus_native_core::state::ParentDepState as _;
                 // println!("called update_parent_dep_state with ty: {:?}", ty);
                 if false {
                     unreachable!();
@@ -129,8 +129,8 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                 }
             }
 
-            fn update_child_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: Option<&'a dioxus_core::VElement<'a>>, children: &[&Self], ctx: &anymap::AnyMap) -> bool{
-                use dioxus_native_core::real_dom_new_api::ChildDepState as _;
+            fn update_child_dep_state<'a>(&'a mut self, ty: std::any::TypeId, node: &'a dioxus_core::VNode<'a>, children: &[&Self], ctx: &anymap::AnyMap) -> bool{
+                use dioxus_native_core::state::ChildDepState as _;
                 // println!("called update_child_dep_state with ty: {:?}", ty);
                 if false {
                     unreachable!()
@@ -141,7 +141,7 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                 }
             }
 
-            fn child_dep_types(&self, mask: &dioxus_native_core::real_dom_new_api::NodeMask) -> Vec<std::any::TypeId>{
+            fn child_dep_types(&self, mask: &dioxus_native_core::state::NodeMask) -> Vec<std::any::TypeId>{
                 let mut dep_types = Vec::new();
                 #(if #child_types::NODE_MASK.overlaps(mask) {
                     dep_types.push(std::any::TypeId::of::<#child_types>());
@@ -149,7 +149,7 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                 dep_types
             }
 
-            fn parent_dep_types(&self, mask: &dioxus_native_core::real_dom_new_api::NodeMask) -> Vec<std::any::TypeId>{
+            fn parent_dep_types(&self, mask: &dioxus_native_core::state::NodeMask) -> Vec<std::any::TypeId>{
                 let mut dep_types = Vec::new();
                 #(if #parent_types::NODE_MASK.overlaps(mask) {
                     dep_types.push(std::any::TypeId::of::<#parent_types>());
@@ -157,7 +157,7 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                 dep_types
             }
 
-            fn node_dep_types(&self, mask: &dioxus_native_core::real_dom_new_api::NodeMask) -> Vec<std::any::TypeId>{
+            fn node_dep_types(&self, mask: &dioxus_native_core::state::NodeMask) -> Vec<std::any::TypeId>{
                 let mut dep_types = Vec::new();
                 #(if #node_types::NODE_MASK.overlaps(mask) {
                     dep_types.push(std::any::TypeId::of::<#node_types>());
@@ -314,7 +314,7 @@ impl<'a> StateMember<'a> {
                     quote!(self.#ident.reduce(#node_view, #get_ctx))
                 }
                 DepKind::ChildDepState => {
-                    quote!(self.#ident.reduce(#node_view, children.iter().map(|s| &s.#dep_ident).collect(), #get_ctx))
+                    quote!(self.#ident.reduce(#node_view, children.iter().map(|s| &s.#dep_ident), #get_ctx))
                 }
                 DepKind::ParentDepState => {
                     quote!(self.#ident.reduce(#node_view, parent.as_ref().map(|p| &p.#dep_ident), #get_ctx))
@@ -337,10 +337,8 @@ impl<'a> StateMember<'a> {
 
     fn type_id(&self) -> quote::__private::TokenStream {
         let ty = &self.mem.ty;
-        // quote!(std::any::TypeId::of::<#ty>())
         quote!({
             let type_id = std::any::TypeId::of::<#ty>();
-            // println!("{:?}", type_id);
             type_id
         })
     }

--- a/packages/native-core-macro/src/lib.rs
+++ b/packages/native-core-macro/src/lib.rs
@@ -1,0 +1,285 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{
+    self,
+    parse::{Parse, ParseStream},
+    Field, Ident, Token, Type,
+};
+
+#[derive(PartialEq)]
+enum DepKind {
+    NodeDepState,
+    ChildDepState,
+    ParentDepState,
+}
+
+// macro that streams data from the State for any attributes that end with _
+#[proc_macro_derive(State, attributes(node_dep_state, child_dep_state, parent_dep_state))]
+pub fn state_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_derive_macro(&ast)
+}
+
+fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
+    let type_name = &ast.ident;
+    let fields: Vec<_> = match &ast.data {
+        syn::Data::Struct(data) => match &data.fields {
+            syn::Fields::Named(e) => &e.named,
+            syn::Fields::Unnamed(_) => todo!("unnamed fields"),
+            syn::Fields::Unit => todo!("unit fields"),
+        }
+        .iter()
+        .collect(),
+        _ => unimplemented!(),
+    };
+    let strct = Struct::parse(&fields);
+    let state_strct = StateStruct::parse(&fields, &strct);
+    let node_dep_state_fields = quote::__private::TokenStream::from_iter(
+        state_strct
+            .state_members
+            .iter()
+            .filter(|f| f.dep_kind == DepKind::NodeDepState)
+            .map(|f| {
+                let ty_id = &f.type_id();
+                let reduce = &f.reduce_self();
+                quote! {
+                    else if ty == #ty_id {
+                        #reduce
+                    }
+                }
+            }),
+    );
+    let child_dep_state_fields = quote::__private::TokenStream::from_iter(
+        state_strct
+            .state_members
+            .iter()
+            .filter(|f| f.dep_kind == DepKind::ChildDepState)
+            .map(|f| {
+                let ty_id = &f.type_id();
+                let reduce = &f.reduce_self();
+                quote! {
+                    else if ty == #ty_id {
+                        #reduce
+                    }
+                }
+            }),
+    );
+    let parent_dep_state_fields = quote::__private::TokenStream::from_iter(
+        state_strct
+            .state_members
+            .iter()
+            .filter(|f| f.dep_kind == DepKind::ParentDepState)
+            .map(|f| {
+                let ty_id = &f.type_id();
+                let reduce = &f.reduce_self();
+                quote! {
+                    else if ty == #ty_id {
+                        #reduce
+                    }
+                }
+            }),
+    );
+
+    let node_types = state_strct
+        .state_members
+        .iter()
+        .filter(|f| f.dep_kind == DepKind::NodeDepState)
+        .map(|f| f.type_id());
+    let child_types = state_strct
+        .state_members
+        .iter()
+        .filter(|f| f.dep_kind == DepKind::ChildDepState)
+        .map(|f| f.type_id());
+    let parent_types = state_strct
+        .state_members
+        .iter()
+        .filter(|f| f.dep_kind == DepKind::ParentDepState)
+        .map(|f| f.type_id());
+
+    let type_name_str = type_name.to_string();
+
+    let gen = quote! {
+        impl State for #type_name{
+            fn update_node_dep_state(&mut self, ty: std::any::TypeId, node: dioxus_native_core::real_dom_new_api::NodeRef, ctx: &anymap::AnyMap){
+                use dioxus_native_core::real_dom_new_api::NodeDepState;
+                if false {}
+                #node_dep_state_fields
+                else{
+                    panic!("{:?} not in {}", ty, #type_name_str);
+                }
+            }
+
+            fn update_parent_dep_state(&mut self, ty: std::any::TypeId, node: dioxus_native_core::real_dom_new_api::NodeRef, parent: &Self, ctx: &anymap::AnyMap){
+                use dioxus_native_core::real_dom_new_api::ParentDepState;
+                if false {}
+                #parent_dep_state_fields
+                else{
+                    panic!("{:?} not in {}", ty, #type_name_str);
+                }
+            }
+
+            fn update_child_dep_state(&mut self, ty: std::any::TypeId, node: dioxus_native_core::real_dom_new_api::NodeRef, children: Vec<&Self>, ctx: &anymap::AnyMap){
+                use dioxus_native_core::real_dom_new_api::ChildDepState;
+                if false {}
+                #child_dep_state_fields
+                else{
+                    panic!("{:?} not in {}", ty, #type_name_str);
+                }
+            }
+
+            fn child_dep_types(&self) -> Vec<std::any::TypeId>{
+                // todo: order should depend on order of dependencies
+                vec![
+                    #(#child_types,)*
+                ]
+            }
+
+            fn parent_dep_types(&self) -> Vec<std::any::TypeId>{
+                // todo: order should depend on order of dependencies
+                vec![
+                    #(#parent_types,)*
+                ]
+            }
+
+            fn node_dep_types(&self) -> Vec<std::any::TypeId>{
+                vec![
+                    #(#node_types,)*
+                ]
+            }
+        }
+    };
+    gen.into()
+}
+
+struct Struct {
+    members: Vec<Member>,
+}
+
+impl Struct {
+    fn parse(fields: &[&Field]) -> Self {
+        let members = fields.iter().filter_map(|f| Member::parse(f)).collect();
+        Self { members }
+    }
+}
+
+struct StateStruct<'a> {
+    state_members: Vec<StateMember<'a>>,
+}
+
+impl<'a> StateStruct<'a> {
+    fn parse(fields: &[&'a Field], strct: &'a Struct) -> Self {
+        let state_members = strct
+            .members
+            .iter()
+            .zip(fields.iter())
+            .filter_map(|(m, f)| StateMember::parse(f, m, &strct))
+            .collect();
+        Self { state_members }
+    }
+}
+
+struct DepTypes {
+    ctx_ty: Option<Type>,
+    dep_ty: Option<Type>,
+}
+
+impl Parse for DepTypes {
+    fn parse(input: ParseStream) -> Result<DepTypes, syn::Error> {
+        let ctx_ty = input.parse::<Type>().ok();
+        let comma = input.parse::<Token![,]>().ok();
+        let dep_ty = input.parse::<Type>().ok();
+        let dep_ty = comma.and(dep_ty);
+        Ok(DepTypes { ctx_ty, dep_ty })
+    }
+}
+
+struct Member {
+    ty: Type,
+    ident: Ident,
+}
+
+impl Member {
+    fn parse(field: &Field) -> Option<Self> {
+        Some(Self {
+            ty: field.ty.clone(),
+            ident: field.ident.as_ref()?.clone(),
+        })
+    }
+}
+
+struct StateMember<'a> {
+    mem: &'a Member,
+    dep_kind: DepKind,
+    dep_mem: Option<&'a Member>,
+    ctx_ty: Option<Type>,
+}
+
+impl<'a> StateMember<'a> {
+    fn parse(field: &Field, mem: &'a Member, parent: &'a Struct) -> Option<StateMember<'a>> {
+        field.attrs.iter().find_map(|a| {
+            let dep_kind = a
+                .path
+                .get_ident()
+                .map(|i| match i.to_string().as_str() {
+                    "node_dep_state" => Some(DepKind::NodeDepState),
+                    "child_dep_state" => Some(DepKind::ChildDepState),
+                    "parent_dep_state" => Some(DepKind::ParentDepState),
+                    _ => None,
+                })
+                .flatten()?;
+            let deps: DepTypes = a.parse_args().ok()?;
+
+            Some(Self {
+                mem,
+                dep_kind,
+                dep_mem: deps
+                    .dep_ty
+                    .map(|ty| parent.members.iter().find(|m| m.ty == ty))
+                    .flatten(),
+                ctx_ty: deps.ctx_ty,
+            })
+        })
+    }
+
+    fn reduce_self(&self) -> quote::__private::TokenStream {
+        let ident = &self.mem.ident;
+        let get_ctx = if let Some(ctx_ty) = &self.ctx_ty {
+            let msg = ctx_ty.to_token_stream().to_string() + " not found in context";
+            quote! {ctx.get().expect(#msg)}
+        } else {
+            quote! {&()}
+        };
+        if let Some(dep_ident) = &self.dep_mem.map(|m| &m.ident) {
+            match self.dep_kind {
+                DepKind::NodeDepState => {
+                    quote!(self.#ident.reduce(node, #get_ctx);)
+                }
+                DepKind::ChildDepState => {
+                    quote!(self.#ident.reduce(node, children.iter().map(|s| &s.#dep_ident).collect(), #get_ctx);)
+                }
+                DepKind::ParentDepState => {
+                    quote!(self.#ident.reduce(node, &parent.#dep_ident, #get_ctx);)
+                }
+            }
+        } else {
+            match self.dep_kind {
+                DepKind::NodeDepState => {
+                    quote!(self.#ident.reduce(node, #get_ctx);)
+                }
+                DepKind::ChildDepState => {
+                    quote!(self.#ident.reduce(node, &(), #get_ctx);)
+                }
+                DepKind::ParentDepState => {
+                    quote!(self.#ident.reduce(node, &(), #get_ctx);)
+                }
+            }
+        }
+    }
+
+    fn type_id(&self) -> quote::__private::TokenStream {
+        let ty = &self.mem.ty;
+        quote!(std::any::TypeId::of::<#ty>())
+    }
+}

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -10,10 +10,12 @@ homepage = "https://dioxuslabs.com"
 dioxus-core = { path = "../core", version = "^0.2.0" }
 dioxus-html = { path = "../html", version = "^0.2.0" }
 dioxus-core-macro = { path = "../core-macro", version = "^0.2.0" }
+dioxus-native-core-macro = { path = "../native-core-macro", version = "^0.2.0" }
 
 stretch2 = { git = "https://github.com/DioxusLabs/stretch" }
 smallvec = "1.6"
 fxhash = "0.2"
+anymap = "0.12.1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/packages/native-core/src/lib.rs
+++ b/packages/native-core/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod layout_attributes;
 pub mod real_dom;
+pub mod real_dom_new_api;

--- a/packages/native-core/src/lib.rs
+++ b/packages/native-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod layout_attributes;
 pub mod real_dom;
 pub mod real_dom_new_api;
+pub use dioxus_native_core_macro;

--- a/packages/native-core/src/lib.rs
+++ b/packages/native-core/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod layout_attributes;
 pub mod real_dom;
-pub mod real_dom_new_api;
+pub mod state;
 pub use dioxus_native_core_macro;

--- a/packages/native-core/src/real_dom_new_api.rs
+++ b/packages/native-core/src/real_dom_new_api.rs
@@ -111,7 +111,7 @@ pub trait NodeDepState {
     fn reduce(&mut self, node: NodeView, ctx: &Self::Ctx) -> bool;
 }
 
-pub trait State {
+pub trait State: Default {
     fn update_node_dep_state<'a>(
         &'a mut self,
         ty: TypeId,

--- a/packages/native-core/src/real_dom_new_api.rs
+++ b/packages/native-core/src/real_dom_new_api.rs
@@ -3,56 +3,141 @@ use std::any::TypeId;
 use anymap::AnyMap;
 use dioxus_core::{Attribute, VElement};
 
-#[repr(transparent)]
-pub struct NodeRef<'a>(&'a VElement<'a>);
-impl<'a> NodeRef<'a> {
-    pub fn new(velement: &'a VElement<'a>) -> Self {
-        Self(velement)
+pub struct NodeView<'a> {
+    inner: &'a VElement<'a>,
+    view: NodeMask,
+}
+impl<'a> NodeView<'a> {
+    pub fn new(velement: &'a VElement<'a>, view: NodeMask) -> Self {
+        Self {
+            inner: velement,
+            view: view,
+        }
     }
 
-    pub fn tag(&self) -> &'a str {
-        self.0.tag
+    pub fn tag(&self) -> Option<&'a str> {
+        if self.view.tag {
+            Some(self.inner.tag)
+        } else {
+            None
+        }
     }
 
     pub fn namespace(&self) -> Option<&'a str> {
-        self.0.namespace
+        if self.view.namespace {
+            self.inner.namespace
+        } else {
+            None
+        }
     }
 
-    pub fn attributes(&self) -> &'a [Attribute<'a>] {
-        self.0.attributes
+    pub fn attributes(&self) -> impl Iterator<Item = &Attribute<'a>> {
+        self.inner
+            .attributes
+            .iter()
+            .filter(|a| self.view.attritutes.contains(&a.name))
     }
 }
 
-pub trait ChildDepState: PartialEq {
+#[derive(Default)]
+pub struct NodeMask {
+    // must be sorted
+    attritutes: &'static [&'static str],
+    tag: bool,
+    namespace: bool,
+}
+
+impl NodeMask {
+    /// attritutes must be sorted!
+    pub const fn new(attritutes: &'static [&'static str], tag: bool, namespace: bool) -> Self {
+        Self {
+            attritutes,
+            tag,
+            namespace,
+        }
+    }
+
+    pub fn verify(&self) {
+        debug_assert!(
+            self.attritutes.windows(2).all(|w| w[0] < w[1]),
+            "attritutes must be increasing"
+        );
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        (self.tag && other.tag)
+            || (self.namespace && other.namespace)
+            || self.attritutes_overlap(other)
+    }
+
+    fn attritutes_overlap(&self, other: &Self) -> bool {
+        let mut self_attrs = self.attritutes.iter();
+        let mut other_attrs = other.attritutes.iter();
+        if let Some(mut other_attr) = other_attrs.next() {
+            while let Some(self_attr) = self_attrs.next() {
+                while other_attr < self_attr {
+                    if let Some(attr) = other_attrs.next() {
+                        other_attr = attr;
+                    } else {
+                        return false;
+                    }
+                }
+                if other_attr == self_attr {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+pub trait ChildDepState {
     type Ctx;
     type DepState: ChildDepState;
-    fn reduce(&mut self, node: NodeRef, children: Vec<&Self::DepState>, ctx: &Self::Ctx);
+    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
+    fn reduce(&mut self, node: NodeView, children: Vec<&Self::DepState>, ctx: &Self::Ctx) -> bool;
 }
 
-pub trait ParentDepState: PartialEq {
+pub trait ParentDepState {
     type Ctx;
     type DepState: ParentDepState;
-    fn reduce(&mut self, node: NodeRef, parent: &Self::DepState, ctx: &Self::Ctx);
+    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
+    fn reduce(&mut self, node: NodeView, parent: &Self::DepState, ctx: &Self::Ctx) -> bool;
 }
 
-pub trait NodeDepState: PartialEq {
+pub trait NodeDepState {
     type Ctx;
-    fn reduce(&mut self, node: NodeRef, ctx: &Self::Ctx);
+    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
+    fn reduce(&mut self, node: NodeView, ctx: &Self::Ctx) -> bool;
 }
 
 pub trait State {
-    fn update_node_dep_state(&mut self, ty: TypeId, node: NodeRef, ctx: &AnyMap);
-    fn child_dep_types(&self) -> Vec<TypeId>;
-
-    fn update_parent_dep_state(&mut self, ty: TypeId, node: NodeRef, parent: &Self, ctx: &AnyMap);
-    fn parent_dep_types(&self) -> Vec<TypeId>;
-
-    fn update_child_dep_state(
-        &mut self,
+    fn update_node_dep_state<'a>(
+        &'a mut self,
         ty: TypeId,
-        node: NodeRef,
+        node: &'a VElement<'a>,
+        ctx: &AnyMap,
+    ) -> bool;
+    /// This must be a valid resolution order. (no nodes updated before a state they rely on)
+    fn child_dep_types(&self, mask: &NodeMask) -> Vec<TypeId>;
+
+    fn update_parent_dep_state<'a>(
+        &'a mut self,
+        ty: TypeId,
+        node: &'a VElement<'a>,
+        parent: &Self,
+        ctx: &AnyMap,
+    ) -> bool;
+    /// This must be a valid resolution order. (no nodes updated before a state they rely on)
+    fn parent_dep_types(&self, mask: &NodeMask) -> Vec<TypeId>;
+
+    fn update_child_dep_state<'a>(
+        &'a mut self,
+        ty: TypeId,
+        node: &'a VElement<'a>,
         children: Vec<&Self>,
         ctx: &AnyMap,
-    );
-    fn node_dep_types(&self) -> Vec<TypeId>;
+    ) -> bool;
+    /// This must be a valid resolution order. (no nodes updated before a state they rely on)
+    fn node_dep_types(&self, mask: &NodeMask) -> Vec<TypeId>;
 }

--- a/packages/native-core/src/real_dom_new_api.rs
+++ b/packages/native-core/src/real_dom_new_api.rs
@@ -3,12 +3,13 @@ use std::any::TypeId;
 use anymap::AnyMap;
 use dioxus_core::{Attribute, VElement};
 
+#[derive(Debug)]
 pub struct NodeView<'a> {
-    inner: &'a VElement<'a>,
+    inner: Option<&'a VElement<'a>>,
     view: NodeMask,
 }
 impl<'a> NodeView<'a> {
-    pub fn new(velement: &'a VElement<'a>, view: NodeMask) -> Self {
+    pub fn new(velement: Option<&'a VElement<'a>>, view: NodeMask) -> Self {
         Self {
             inner: velement,
             view: view,
@@ -17,7 +18,7 @@ impl<'a> NodeView<'a> {
 
     pub fn tag(&self) -> Option<&'a str> {
         if self.view.tag {
-            Some(self.inner.tag)
+            self.inner.map(|el| el.tag)
         } else {
             None
         }
@@ -25,7 +26,7 @@ impl<'a> NodeView<'a> {
 
     pub fn namespace(&self) -> Option<&'a str> {
         if self.view.namespace {
-            self.inner.namespace
+            self.inner.map(|el| el.namespace).flatten()
         } else {
             None
         }
@@ -33,35 +34,164 @@ impl<'a> NodeView<'a> {
 
     pub fn attributes(&self) -> impl Iterator<Item = &Attribute<'a>> {
         self.inner
-            .attributes
+            .map(|el| el.attributes)
+            .unwrap_or_default()
             .iter()
-            .filter(|a| self.view.attritutes.contains(&a.name))
+            .filter(|a| self.view.attritutes.contains_attribute(&a.name))
     }
 }
 
-#[derive(Default)]
+#[derive(PartialEq, Clone, Debug)]
+pub enum AttributeMask {
+    All,
+    Dynamic(Vec<&'static str>),
+    Static(&'static [&'static str]),
+}
+
+impl AttributeMask {
+    pub const NONE: Self = Self::Static(&[]);
+
+    fn contains_attribute(&self, attr: &'static str) -> bool {
+        match self {
+            AttributeMask::All => true,
+            AttributeMask::Dynamic(l) => l.contains(&attr),
+            AttributeMask::Static(l) => l.contains(&attr),
+        }
+    }
+
+    pub fn single(new: &'static str) -> Self {
+        Self::Dynamic(vec![new])
+    }
+
+    pub fn verify(&self) {
+        match &self {
+            AttributeMask::Static(attrs) => debug_assert!(
+                attrs.windows(2).all(|w| w[0] < w[1]),
+                "attritutes must be increasing"
+            ),
+            AttributeMask::Dynamic(attrs) => debug_assert!(
+                attrs.windows(2).all(|w| w[0] < w[1]),
+                "attritutes must be increasing"
+            ),
+            _ => (),
+        }
+    }
+
+    pub fn union(&self, other: &Self) -> Self {
+        pub fn union_iter(
+            s_iter: impl Iterator<Item = &'static str>,
+            o_iter: impl Iterator<Item = &'static str>,
+        ) -> Vec<&'static str> {
+            let mut s_peekable = s_iter.peekable();
+            let mut o_peekable = o_iter.peekable();
+            let mut v = Vec::new();
+            while let Some(s_i) = s_peekable.peek() {
+                loop {
+                    if let Some(o_i) = o_peekable.peek() {
+                        if o_i > s_i {
+                            break;
+                        } else {
+                            v.push(o_peekable.next().unwrap());
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                v.push(s_peekable.next().unwrap());
+            }
+            while let Some(o_i) = o_peekable.next() {
+                v.push(o_i);
+            }
+            v
+        }
+
+        let new = match (self, other) {
+            (AttributeMask::Dynamic(s), AttributeMask::Dynamic(o)) => {
+                AttributeMask::Dynamic(union_iter(s.iter().copied(), o.iter().copied()))
+            }
+            (AttributeMask::Static(s), AttributeMask::Dynamic(o)) => {
+                AttributeMask::Dynamic(union_iter(s.iter().copied(), o.iter().copied()))
+            }
+            (AttributeMask::Dynamic(s), AttributeMask::Static(o)) => {
+                AttributeMask::Dynamic(union_iter(s.iter().copied(), o.iter().copied()))
+            }
+            (AttributeMask::Static(s), AttributeMask::Static(o)) => {
+                AttributeMask::Dynamic(union_iter(s.iter().copied(), o.iter().copied()))
+            }
+            _ => AttributeMask::All,
+        };
+        new.verify();
+        new
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        fn overlaps_iter(
+            mut self_iter: impl Iterator<Item = &'static str>,
+            mut other_iter: impl Iterator<Item = &'static str>,
+        ) -> bool {
+            if let Some(mut other_attr) = other_iter.next() {
+                while let Some(self_attr) = self_iter.next() {
+                    while other_attr < self_attr {
+                        if let Some(attr) = other_iter.next() {
+                            other_attr = attr;
+                        } else {
+                            return false;
+                        }
+                    }
+                    if other_attr == self_attr {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        match (self, other) {
+            (AttributeMask::All, AttributeMask::All) => true,
+            (AttributeMask::All, AttributeMask::Dynamic(v)) => !v.is_empty(),
+            (AttributeMask::All, AttributeMask::Static(s)) => !s.is_empty(),
+            (AttributeMask::Dynamic(v), AttributeMask::All) => !v.is_empty(),
+            (AttributeMask::Static(s), AttributeMask::All) => !s.is_empty(),
+            (AttributeMask::Dynamic(v1), AttributeMask::Dynamic(v2)) => {
+                overlaps_iter(v1.iter().copied(), v2.iter().copied())
+            }
+            (AttributeMask::Dynamic(v), AttributeMask::Static(s)) => {
+                overlaps_iter(v.iter().copied(), s.iter().copied())
+            }
+            (AttributeMask::Static(s), AttributeMask::Dynamic(v)) => {
+                overlaps_iter(v.iter().copied(), s.iter().copied())
+            }
+            (AttributeMask::Static(s1), AttributeMask::Static(s2)) => {
+                overlaps_iter(s1.iter().copied(), s2.iter().copied())
+            }
+        }
+    }
+}
+
+impl Default for AttributeMask {
+    fn default() -> Self {
+        AttributeMask::Static(&[])
+    }
+}
+
+#[derive(Default, PartialEq, Clone, Debug)]
 pub struct NodeMask {
     // must be sorted
-    attritutes: &'static [&'static str],
+    attritutes: AttributeMask,
     tag: bool,
     namespace: bool,
 }
 
 impl NodeMask {
+    pub const NONE: Self = Self::new(AttributeMask::Static(&[]), false, false);
+    pub const ALL: Self = Self::new(AttributeMask::All, true, true);
+
     /// attritutes must be sorted!
-    pub const fn new(attritutes: &'static [&'static str], tag: bool, namespace: bool) -> Self {
+    pub const fn new(attritutes: AttributeMask, tag: bool, namespace: bool) -> Self {
         Self {
             attritutes,
             tag,
             namespace,
         }
-    }
-
-    pub fn verify(&self) {
-        debug_assert!(
-            self.attritutes.windows(2).all(|w| w[0] < w[1]),
-            "attritutes must be increasing"
-        );
     }
 
     pub fn overlaps(&self, other: &Self) -> bool {
@@ -71,51 +201,48 @@ impl NodeMask {
     }
 
     fn attritutes_overlap(&self, other: &Self) -> bool {
-        let mut self_attrs = self.attritutes.iter();
-        let mut other_attrs = other.attritutes.iter();
-        if let Some(mut other_attr) = other_attrs.next() {
-            while let Some(self_attr) = self_attrs.next() {
-                while other_attr < self_attr {
-                    if let Some(attr) = other_attrs.next() {
-                        other_attr = attr;
-                    } else {
-                        return false;
-                    }
-                }
-                if other_attr == self_attr {
-                    return true;
-                }
-            }
-        }
-        false
+        self.attritutes.overlaps(&other.attritutes)
     }
 }
 
+/// This state is derived from children. For example a node's size could be derived from the size of children.
+/// Called when the current node's node properties are modified, a child's [BubbledUpState] is modified or a child is removed.
+/// Called at most once per update.
 pub trait ChildDepState {
+    /// The context is passed to the [PushedDownState::reduce] when it is pushed down.
+    /// This is sometimes nessisary for lifetime purposes.
     type Ctx;
     type DepState: ChildDepState;
-    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, false, false);
     fn reduce(&mut self, node: NodeView, children: Vec<&Self::DepState>, ctx: &Self::Ctx) -> bool;
 }
 
+/// This state that is passed down to children. For example text properties (`<b>` `<i>` `<u>`) would be passed to children.
+/// Called when the current node's node properties are modified or a parrent's [PushedDownState] is modified.
+/// Called at most once per update.
 pub trait ParentDepState {
+    /// The context is passed to the [PushedDownState::reduce] when it is pushed down.
+    /// This is sometimes nessisary for lifetime purposes.
     type Ctx;
     type DepState: ParentDepState;
-    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
-    fn reduce(&mut self, node: NodeView, parent: &Self::DepState, ctx: &Self::Ctx) -> bool;
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, false, false);
+    fn reduce(&mut self, node: NodeView, parent: Option<&Self::DepState>, ctx: &Self::Ctx) -> bool;
 }
 
+/// This state that is upadated lazily. For example any propertys that do not effect other parts of the dom like bg-color.
+/// Called when the current node's node properties are modified or a parrent's [PushedDownState] is modified.
+/// Called at most once per update.
 pub trait NodeDepState {
     type Ctx;
-    const NODE_MASK: NodeMask = NodeMask::new(&[], false, false);
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, false, false);
     fn reduce(&mut self, node: NodeView, ctx: &Self::Ctx) -> bool;
 }
 
-pub trait State: Default {
+pub trait State: Default + Clone {
     fn update_node_dep_state<'a>(
         &'a mut self,
         ty: TypeId,
-        node: &'a VElement<'a>,
+        node: Option<&'a VElement<'a>>,
         ctx: &AnyMap,
     ) -> bool;
     /// This must be a valid resolution order. (no nodes updated before a state they rely on)
@@ -124,8 +251,8 @@ pub trait State: Default {
     fn update_parent_dep_state<'a>(
         &'a mut self,
         ty: TypeId,
-        node: &'a VElement<'a>,
-        parent: &Self,
+        node: Option<&'a VElement<'a>>,
+        parent: Option<&Self>,
         ctx: &AnyMap,
     ) -> bool;
     /// This must be a valid resolution order. (no nodes updated before a state they rely on)
@@ -134,8 +261,8 @@ pub trait State: Default {
     fn update_child_dep_state<'a>(
         &'a mut self,
         ty: TypeId,
-        node: &'a VElement<'a>,
-        children: Vec<&Self>,
+        node: Option<&'a VElement<'a>>,
+        children: &[&Self],
         ctx: &AnyMap,
     ) -> bool;
     /// This must be a valid resolution order. (no nodes updated before a state they rely on)

--- a/packages/native-core/src/real_dom_new_api.rs
+++ b/packages/native-core/src/real_dom_new_api.rs
@@ -1,0 +1,58 @@
+use std::any::TypeId;
+
+use anymap::AnyMap;
+use dioxus_core::{Attribute, VElement};
+
+#[repr(transparent)]
+pub struct NodeRef<'a>(&'a VElement<'a>);
+impl<'a> NodeRef<'a> {
+    pub fn new(velement: &'a VElement<'a>) -> Self {
+        Self(velement)
+    }
+
+    pub fn tag(&self) -> &'a str {
+        self.0.tag
+    }
+
+    pub fn namespace(&self) -> Option<&'a str> {
+        self.0.namespace
+    }
+
+    pub fn attributes(&self) -> &'a [Attribute<'a>] {
+        self.0.attributes
+    }
+}
+
+pub trait ChildDepState: PartialEq {
+    type Ctx;
+    type DepState: ChildDepState;
+    fn reduce(&mut self, node: NodeRef, children: Vec<&Self::DepState>, ctx: &Self::Ctx);
+}
+
+pub trait ParentDepState: PartialEq {
+    type Ctx;
+    type DepState: ParentDepState;
+    fn reduce(&mut self, node: NodeRef, parent: &Self::DepState, ctx: &Self::Ctx);
+}
+
+pub trait NodeDepState: PartialEq {
+    type Ctx;
+    fn reduce(&mut self, node: NodeRef, ctx: &Self::Ctx);
+}
+
+pub trait State {
+    fn update_node_dep_state(&mut self, ty: TypeId, node: NodeRef, ctx: &AnyMap);
+    fn child_dep_types(&self) -> Vec<TypeId>;
+
+    fn update_parent_dep_state(&mut self, ty: TypeId, node: NodeRef, parent: &Self, ctx: &AnyMap);
+    fn parent_dep_types(&self) -> Vec<TypeId>;
+
+    fn update_child_dep_state(
+        &mut self,
+        ty: TypeId,
+        node: NodeRef,
+        children: Vec<&Self>,
+        ctx: &AnyMap,
+    );
+    fn node_dep_types(&self) -> Vec<TypeId>;
+}

--- a/packages/native-core/tests/change_nodes.rs
+++ b/packages/native-core/tests/change_nodes.rs
@@ -3,7 +3,12 @@ use dioxus_core::*;
 use dioxus_core_macro::*;
 use dioxus_html as dioxus_elements;
 use dioxus_native_core::real_dom::RealDom;
+use dioxus_native_core::real_dom_new_api::State;
+use dioxus_native_core_macro::State;
 use std::cell::Cell;
+
+#[derive(State, Default, Clone)]
+struct Empty {}
 
 #[test]
 fn remove_node() {
@@ -20,7 +25,7 @@ fn remove_node() {
         }
     });
 
-    let mut dom: RealDom<(), ()> = RealDom::new();
+    let mut dom: RealDom<Empty> = RealDom::new();
 
     let _to_update = dom.apply_mutations(vec![mutations]);
     let child_div = VElement {
@@ -92,7 +97,7 @@ fn add_node() {
         div{}
     });
 
-    let mut dom: RealDom<(), ()> = RealDom::new();
+    let mut dom: RealDom<Empty> = RealDom::new();
 
     let _to_update = dom.apply_mutations(vec![mutations]);
 

--- a/packages/native-core/tests/change_nodes.rs
+++ b/packages/native-core/tests/change_nodes.rs
@@ -3,7 +3,7 @@ use dioxus_core::*;
 use dioxus_core_macro::*;
 use dioxus_html as dioxus_elements;
 use dioxus_native_core::real_dom::RealDom;
-use dioxus_native_core::real_dom_new_api::State;
+use dioxus_native_core::state::State;
 use dioxus_native_core_macro::State;
 use std::cell::Cell;
 

--- a/packages/native-core/tests/initial_build.rs
+++ b/packages/native-core/tests/initial_build.rs
@@ -5,7 +5,7 @@ use dioxus_core::*;
 use dioxus_core_macro::*;
 use dioxus_html as dioxus_elements;
 use dioxus_native_core::real_dom::RealDom;
-use dioxus_native_core::real_dom_new_api::State;
+use dioxus_native_core::state::State;
 use dioxus_native_core_macro::State;
 
 #[derive(State, Default, Clone)]

--- a/packages/native-core/tests/initial_build.rs
+++ b/packages/native-core/tests/initial_build.rs
@@ -5,6 +5,11 @@ use dioxus_core::*;
 use dioxus_core_macro::*;
 use dioxus_html as dioxus_elements;
 use dioxus_native_core::real_dom::RealDom;
+use dioxus_native_core::real_dom_new_api::State;
+use dioxus_native_core_macro::State;
+
+#[derive(State, Default, Clone)]
+struct Empty {}
 
 #[test]
 fn initial_build_simple() {
@@ -21,7 +26,7 @@ fn initial_build_simple() {
         div{}
     });
 
-    let mut dom: RealDom<(), ()> = RealDom::new();
+    let mut dom: RealDom<Empty> = RealDom::new();
 
     let _to_update = dom.apply_mutations(vec![mutations]);
     let root_div = VElement {
@@ -60,7 +65,7 @@ fn initial_build_with_children() {
         }
     });
 
-    let mut dom: RealDom<(), ()> = RealDom::new();
+    let mut dom: RealDom<Empty> = RealDom::new();
 
     let _to_update = dom.apply_mutations(vec![mutations]);
     let first_text = VText {

--- a/packages/native-core/tests/parse.rs
+++ b/packages/native-core/tests/parse.rs
@@ -1,0 +1,62 @@
+use dioxus_native_core::real_dom_new_api::*;
+use dioxus_native_core_macro::*;
+
+#[derive(State)]
+struct Z {
+    // depends on just attributes and no context
+    #[node_dep_state()]
+    x: A,
+    // depends on attributes, the B component of children and i32 context
+    #[child_dep_state(i32, B)]
+    y: B,
+    // depends on attributes, the C component of it's parent and a u8 context
+    #[parent_dep_state(u8, C)]
+    z: C,
+}
+
+// struct Z {
+//     x: A,
+//     y: B,
+//     z: C,
+// }
+
+use dioxus_native_core::real_dom_new_api::NodeDepState;
+
+#[derive(PartialEq)]
+struct A;
+impl NodeDepState for A {
+    type Ctx = ();
+    fn reduce(&mut self, _: NodeRef, _: &()) {
+        todo!()
+    }
+}
+
+#[derive(PartialEq)]
+struct B;
+impl ChildDepState for B {
+    type Ctx = i32;
+    type DepState = Self;
+    fn reduce(
+        &mut self,
+        _: dioxus_native_core::real_dom_new_api::NodeRef,
+        _: Vec<&Self::DepState>,
+        _: &i32,
+    ) {
+        todo!()
+    }
+}
+
+#[derive(PartialEq)]
+struct C;
+impl ParentDepState for C {
+    type Ctx = u8;
+    type DepState = Self;
+    fn reduce(
+        &mut self,
+        _: dioxus_native_core::real_dom_new_api::NodeRef,
+        _: &Self::DepState,
+        _: &u8,
+    ) {
+        todo!()
+    }
+}

--- a/packages/native-core/tests/parse.rs
+++ b/packages/native-core/tests/parse.rs
@@ -26,7 +26,7 @@ use dioxus_native_core::real_dom_new_api::NodeDepState;
 struct A;
 impl NodeDepState for A {
     type Ctx = ();
-    fn reduce(&mut self, _: NodeRef, _: &()) {
+    fn reduce(&mut self, _: NodeView, _: &()) -> bool {
         todo!()
     }
 }
@@ -38,10 +38,10 @@ impl ChildDepState for B {
     type DepState = Self;
     fn reduce(
         &mut self,
-        _: dioxus_native_core::real_dom_new_api::NodeRef,
+        _: dioxus_native_core::real_dom_new_api::NodeView,
         _: Vec<&Self::DepState>,
         _: &i32,
-    ) {
+    ) -> bool {
         todo!()
     }
 }
@@ -53,10 +53,10 @@ impl ParentDepState for C {
     type DepState = Self;
     fn reduce(
         &mut self,
-        _: dioxus_native_core::real_dom_new_api::NodeRef,
+        _: dioxus_native_core::real_dom_new_api::NodeView,
         _: &Self::DepState,
         _: &u8,
-    ) {
+    ) -> bool {
         todo!()
     }
 }

--- a/packages/native-core/tests/parse.rs
+++ b/packages/native-core/tests/parse.rs
@@ -1,16 +1,16 @@
 use dioxus_native_core::real_dom_new_api::*;
 use dioxus_native_core_macro::*;
 
-#[derive(State)]
+#[derive(State, Default, Clone)]
 struct Z {
     // depends on just attributes and no context
     #[node_dep_state()]
     x: A,
     // depends on attributes, the B component of children and i32 context
-    #[child_dep_state(i32, B)]
+    #[child_dep_state(B, i32)]
     y: B,
     // depends on attributes, the C component of it's parent and a u8 context
-    #[parent_dep_state(u8, C)]
+    #[parent_dep_state(C, u8)]
     z: C,
 }
 
@@ -22,7 +22,7 @@ struct Z {
 
 use dioxus_native_core::real_dom_new_api::NodeDepState;
 
-#[derive(PartialEq)]
+#[derive(Default, Clone)]
 struct A;
 impl NodeDepState for A {
     type Ctx = ();
@@ -31,7 +31,7 @@ impl NodeDepState for A {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Default, Clone)]
 struct B;
 impl ChildDepState for B {
     type Ctx = i32;
@@ -46,7 +46,7 @@ impl ChildDepState for B {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Default, Clone)]
 struct C;
 impl ParentDepState for C {
     type Ctx = u8;
@@ -54,7 +54,7 @@ impl ParentDepState for C {
     fn reduce(
         &mut self,
         _: dioxus_native_core::real_dom_new_api::NodeView,
-        _: &Self::DepState,
+        _: Option<&Self::DepState>,
         _: &u8,
     ) -> bool {
         todo!()

--- a/packages/native-core/tests/parse.rs
+++ b/packages/native-core/tests/parse.rs
@@ -1,4 +1,4 @@
-use dioxus_native_core::real_dom_new_api::*;
+use dioxus_native_core::state::*;
 use dioxus_native_core_macro::*;
 
 #[derive(State, Default, Clone)]
@@ -20,7 +20,7 @@ struct Z {
 //     z: C,
 // }
 
-use dioxus_native_core::real_dom_new_api::NodeDepState;
+use dioxus_native_core::state::NodeDepState;
 
 #[derive(Default, Clone)]
 struct A;
@@ -36,12 +36,15 @@ struct B;
 impl ChildDepState for B {
     type Ctx = i32;
     type DepState = Self;
-    fn reduce(
+    fn reduce<'a>(
         &mut self,
-        _: dioxus_native_core::real_dom_new_api::NodeView,
-        _: Vec<&Self::DepState>,
+        _: dioxus_native_core::state::NodeView,
+        _: impl Iterator<Item = &'a Self::DepState>,
         _: &i32,
-    ) -> bool {
+    ) -> bool
+    where
+        Self::DepState: 'a,
+    {
         todo!()
     }
 }
@@ -53,7 +56,7 @@ impl ParentDepState for C {
     type DepState = Self;
     fn reduce(
         &mut self,
-        _: dioxus_native_core::real_dom_new_api::NodeView,
+        _: dioxus_native_core::state::NodeView,
         _: Option<&Self::DepState>,
         _: &u8,
     ) -> bool {

--- a/packages/native-core/tests/update_state.rs
+++ b/packages/native-core/tests/update_state.rs
@@ -72,7 +72,7 @@ struct BubbledUpStateTester(Option<String>, Vec<Box<BubbledUpStateTester>>);
 impl ChildDepState for BubbledUpStateTester {
     type Ctx = u32;
     type DepState = Self;
-    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, true, false);
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, true, false, false);
     fn reduce<'a>(
         &mut self,
         node: NodeView,
@@ -96,7 +96,7 @@ struct PushedDownStateTester(Option<String>, Option<Box<PushedDownStateTester>>)
 impl ParentDepState for PushedDownStateTester {
     type Ctx = u32;
     type DepState = Self;
-    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, true, false);
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::NONE, true, false, false);
     fn reduce(&mut self, node: NodeView, parent: Option<&Self::DepState>, ctx: &Self::Ctx) -> bool {
         assert_eq!(*ctx, 42);
         *self = PushedDownStateTester(
@@ -121,7 +121,7 @@ struct StateTester {
 struct NodeStateTester(Option<String>, Vec<(String, String)>);
 impl NodeDepState for NodeStateTester {
     type Ctx = u32;
-    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::All, true, false);
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::All, true, false, false);
     fn reduce(&mut self, node: NodeView, ctx: &Self::Ctx) -> bool {
         assert_eq!(*ctx, 42);
         *self = NodeStateTester(

--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -25,3 +25,4 @@ futures = "0.3.19"
 stretch2 = { git = "https://github.com/DioxusLabs/stretch" }
 smallvec = "1.6"
 fxhash = "0.2"
+anymap = "0.12.1"

--- a/packages/tui/src/hooks.rs
+++ b/packages/tui/src/hooks.rs
@@ -14,8 +14,6 @@ use std::{
 };
 use stretch2::{prelude::Layout, Stretch};
 
-use crate::layout::StretchLayout;
-use crate::style_attributes::StyleModifier;
 use crate::{Dom, Node};
 
 // a wrapper around the input state for easier access

--- a/packages/tui/src/layout.rs
+++ b/packages/tui/src/layout.rs
@@ -1,83 +1,90 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use dioxus_core::*;
 use dioxus_native_core::layout_attributes::apply_layout_attributes;
-use dioxus_native_core::real_dom::BubbledUpState;
+use dioxus_native_core::state::{AttributeMask, ChildDepState, NodeMask, NodeView};
 use stretch2::prelude::*;
 
-/// the size
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct StretchLayout {
     pub style: Style,
     pub node: Option<Node>,
 }
 
-impl BubbledUpState for StretchLayout {
-    type Ctx = Stretch;
+impl ChildDepState for StretchLayout {
+    type Ctx = Rc<RefCell<Stretch>>;
+    type DepState = Self;
+    // todo: update mask
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::All, false, false, true);
 
     /// Setup the layout
-    fn reduce<'a, I>(&mut self, children: I, vnode: &VNode, stretch: &mut Self::Ctx)
+    fn reduce<'a>(
+        &mut self,
+        node: NodeView,
+        children: impl Iterator<Item = &'a Self::DepState>,
+        ctx: &Self::Ctx,
+    ) -> bool
     where
-        I: Iterator<Item = &'a Self>,
-        Self: 'a,
+        Self::DepState: 'a,
     {
-        match vnode {
-            VNode::Text(t) => {
-                let char_len = t.text.chars().count();
+        let mut stretch = ctx.borrow_mut();
+        if let Some(text) = node.text() {
+            let char_len = text.chars().count();
 
-                let style = Style {
-                    size: Size {
-                        // characters are 1 point tall
-                        height: Dimension::Points(1.0),
+            let style = Style {
+                size: Size {
+                    // characters are 1 point tall
+                    height: Dimension::Points(1.0),
 
-                        // text is as long as it is declared
-                        width: Dimension::Points(char_len as f32),
-                    },
-                    ..Default::default()
-                };
+                    // text is as long as it is declared
+                    width: Dimension::Points(char_len as f32),
+                },
+                ..Default::default()
+            };
 
-                if let Some(n) = self.node {
-                    if self.style != style {
-                        stretch.set_style(n, style).unwrap();
-                    }
-                } else {
-                    self.node = Some(stretch.new_node(style, &[]).unwrap());
+            if let Some(n) = self.node {
+                if self.style != style {
+                    stretch.set_style(n, style).unwrap();
                 }
-
-                self.style = style;
+            } else {
+                self.node = Some(stretch.new_node(style, &[]).unwrap());
             }
-            VNode::Element(el) => {
-                // gather up all the styles from the attribute list
-                let mut style = Style::default();
 
-                for &Attribute { name, value, .. } in el.attributes {
-                    apply_layout_attributes(name, value, &mut style);
-                }
+            self.style = style;
+        } else {
+            // gather up all the styles from the attribute list
+            let mut style = Style::default();
 
-                // the root node fills the entire area
-                if el.id.get() == Some(ElementId(0)) {
-                    apply_layout_attributes("width", "100%", &mut style);
-                    apply_layout_attributes("height", "100%", &mut style);
-                }
-
-                // Set all direct nodes as our children
-                let mut child_layout = vec![];
-                for l in children {
-                    child_layout.push(l.node.unwrap());
-                }
-
-                if let Some(n) = self.node {
-                    if stretch.children(n).unwrap() != child_layout {
-                        stretch.set_children(n, &child_layout).unwrap();
-                    }
-                    if self.style != style {
-                        stretch.set_style(n, style).unwrap();
-                    }
-                } else {
-                    self.node = Some(stretch.new_node(style, &child_layout).unwrap());
-                }
-
-                self.style = style;
+            for &Attribute { name, value, .. } in node.attributes() {
+                apply_layout_attributes(name, value, &mut style);
             }
-            _ => (),
+
+            // the root node fills the entire area
+            if node.id() == ElementId(0) {
+                apply_layout_attributes("width", "100%", &mut style);
+                apply_layout_attributes("height", "100%", &mut style);
+            }
+
+            // Set all direct nodes as our children
+            let mut child_layout = vec![];
+            for l in children {
+                child_layout.push(l.node.unwrap());
+            }
+
+            if let Some(n) = self.node {
+                if stretch.children(n).unwrap() != child_layout {
+                    stretch.set_children(n, &child_layout).unwrap();
+                }
+                if self.style != style {
+                    stretch.set_style(n, style).unwrap();
+                }
+            } else {
+                self.node = Some(stretch.new_node(style, &child_layout).unwrap());
+            }
+
+            self.style = style;
         }
+        true
     }
 }

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -30,7 +30,6 @@ mod widget;
 
 pub use config::*;
 pub use hooks::*;
-pub use render::*;
 
 type Dom = RealDom<NodeState>;
 type Node = dioxus_native_core::real_dom::Node<NodeState>;
@@ -111,7 +110,7 @@ fn render_vdom(
     handler: RinkInputHandler,
     cfg: Config,
     mut rdom: Dom,
-    mut stretch: Rc<RefCell<Stretch>>,
+    stretch: Rc<RefCell<Stretch>>,
     mut register_event: impl FnMut(crossterm::event::Event),
 ) -> Result<()> {
     tokio::runtime::Builder::new_current_thread()

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -6,7 +6,9 @@ use crossterm::{
 };
 use dioxus_core::exports::futures_channel::mpsc::unbounded;
 use dioxus_core::*;
-use dioxus_native_core::real_dom::RealDom;
+use dioxus_native_core::{
+    dioxus_native_core_macro::State, real_dom::RealDom, real_dom_new_api::State,
+};
 use futures::{
     channel::mpsc::{UnboundedReceiver, UnboundedSender},
     pin_mut, StreamExt,
@@ -28,6 +30,9 @@ mod widget;
 pub use config::*;
 pub use hooks::*;
 pub use render::*;
+
+#[derive(Debug, Clone, State, Default)]
+struct NodeState {}
 
 #[derive(Clone)]
 pub struct TuiContext {

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use anymap::AnyMap;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture, Event as TermEvent, KeyCode, KeyModifiers},
     execute,
@@ -6,14 +7,14 @@ use crossterm::{
 };
 use dioxus_core::exports::futures_channel::mpsc::unbounded;
 use dioxus_core::*;
-use dioxus_native_core::{
-    dioxus_native_core_macro::State, real_dom::RealDom, real_dom_new_api::State,
-};
+use dioxus_native_core::{dioxus_native_core_macro::State, real_dom::RealDom, state::*};
 use futures::{
     channel::mpsc::{UnboundedReceiver, UnboundedSender},
     pin_mut, StreamExt,
 };
 use layout::StretchLayout;
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::{io, time::Duration};
 use stretch2::{prelude::Size, Stretch};
 use style_attributes::StyleModifier;
@@ -31,8 +32,17 @@ pub use config::*;
 pub use hooks::*;
 pub use render::*;
 
+type Dom = RealDom<NodeState>;
+type Node = dioxus_native_core::real_dom::Node<NodeState>;
+
 #[derive(Debug, Clone, State, Default)]
-struct NodeState {}
+struct NodeState {
+    #[child_dep_state(StretchLayout, RefCell<Stretch>)]
+    layout: StretchLayout,
+    // depends on attributes, the C component of it's parent and a u8 context
+    #[parent_dep_state(StyleModifier)]
+    style: StyleModifier,
+}
 
 #[derive(Clone)]
 pub struct TuiContext {
@@ -75,13 +85,13 @@ pub fn launch_cfg(app: Component<()>, cfg: Config) {
     cx.provide_root_context(state);
     cx.provide_root_context(TuiContext { tx: event_tx_clone });
 
-    let mut rdom: RealDom<StretchLayout, StyleModifier> = RealDom::new();
+    let mut rdom: Dom = RealDom::new();
     let mutations = dom.rebuild();
     let to_update = rdom.apply_mutations(vec![mutations]);
-    let mut stretch = Stretch::new();
-    let _to_rerender = rdom
-        .update_state(&dom, to_update, &mut stretch, &mut ())
-        .unwrap();
+    let stretch = Rc::new(RefCell::new(Stretch::new()));
+    let mut any_map = AnyMap::new();
+    any_map.insert(stretch.clone());
+    let _to_rerender = rdom.update_state(&dom, to_update, any_map).unwrap();
 
     render_vdom(
         &mut dom,
@@ -100,8 +110,8 @@ fn render_vdom(
     mut event_reciever: UnboundedReceiver<InputEvent>,
     handler: RinkInputHandler,
     cfg: Config,
-    mut rdom: RealDom<StretchLayout, StyleModifier>,
-    mut stretch: Stretch,
+    mut rdom: Dom,
+    mut stretch: Rc<RefCell<Stretch>>,
     mut register_event: impl FnMut(crossterm::event::Event),
 ) -> Result<()> {
     tokio::runtime::Builder::new_current_thread()
@@ -119,7 +129,7 @@ fn render_vdom(
                 terminal.clear().unwrap();
             }
 
-            let mut to_rerender: fxhash::FxHashSet<usize> = vec![0].into_iter().collect();
+            let to_rerender: fxhash::FxHashSet<usize> = vec![0].into_iter().collect();
             let mut resized = true;
 
             loop {
@@ -136,15 +146,11 @@ fn render_vdom(
 
                 if !to_rerender.is_empty() || resized {
                     resized = false;
-                    fn resize(
-                        dims: Rect,
-                        stretch: &mut Stretch,
-                        rdom: &RealDom<StretchLayout, StyleModifier>,
-                    ) {
+                    fn resize(dims: Rect, stretch: &mut Stretch, rdom: &Dom) {
                         let width = dims.width;
                         let height = dims.height;
                         let root_id = rdom.root_id();
-                        let root_node = rdom[root_id].up_state.node.unwrap();
+                        let root_node = rdom[root_id].state.layout.node.unwrap();
 
                         stretch
                             .compute_layout(
@@ -159,9 +165,9 @@ fn render_vdom(
                     if let Some(terminal) = &mut terminal {
                         terminal.draw(|frame| {
                             // size is guaranteed to not change when rendering
-                            resize(frame.size(), &mut stretch, &rdom);
+                            resize(frame.size(), &mut stretch.borrow_mut(), &rdom);
                             let root = &rdom[rdom.root_id()];
-                            render::render_vnode(frame, &stretch, &rdom, &root, cfg);
+                            render::render_vnode(frame, &stretch.borrow(), &rdom, &root, cfg);
                         })?;
                     } else {
                         resize(
@@ -171,7 +177,7 @@ fn render_vdom(
                                 width: 300,
                                 height: 300,
                             },
-                            &mut stretch,
+                            &mut stretch.borrow_mut(),
                             &rdom,
                         );
                     }
@@ -212,7 +218,7 @@ fn render_vdom(
 
                 {
                     // resolve events before rendering
-                    let evts = handler.get_events(&stretch, &mut rdom);
+                    let evts = handler.get_events(&stretch.borrow(), &mut rdom);
                     for e in evts {
                         vdom.handle_message(SchedulerMsg::Event(e));
                     }
@@ -220,11 +226,9 @@ fn render_vdom(
                     // updates the dom's nodes
                     let to_update = rdom.apply_mutations(mutations);
                     // update the style and layout
-                    to_rerender.extend(
-                        rdom.update_state(vdom, to_update, &mut stretch, &mut ())
-                            .unwrap()
-                            .iter(),
-                    )
+                    let mut any_map = AnyMap::new();
+                    any_map.insert(stretch.clone());
+                    let _to_rerender = rdom.update_state(&vdom, to_update, any_map).unwrap();
                 }
             }
 

--- a/packages/tui/src/render.rs
+++ b/packages/tui/src/render.rs
@@ -1,8 +1,5 @@
 use crate::layout::StretchLayout;
-use dioxus_native_core::{
-    layout_attributes::UnitSystem,
-    real_dom::{Node, RealDom},
-};
+use dioxus_native_core::layout_attributes::UnitSystem;
 use std::io::Stdout;
 use stretch2::{
     geometry::Point,
@@ -15,16 +12,16 @@ use crate::{
     style::{RinkColor, RinkStyle},
     style_attributes::{BorderEdge, BorderStyle},
     widget::{RinkBuffer, RinkCell, RinkWidget, WidgetWithContext},
-    Config, StyleModifier,
+    Config, Dom, Node, StyleModifier,
 };
 
 const RADIUS_MULTIPLIER: [f32; 2] = [1.0, 0.5];
 
-pub fn render_vnode(
+pub(crate) fn render_vnode(
     frame: &mut tui::Frame<CrosstermBackend<Stdout>>,
     layout: &Stretch,
-    rdom: &RealDom<StretchLayout, StyleModifier>,
-    node: &Node<StretchLayout, StyleModifier>,
+    rdom: &Dom,
+    node: &Node,
     cfg: Config,
 ) {
     use dioxus_native_core::real_dom::NodeType;
@@ -33,7 +30,7 @@ pub fn render_vnode(
         return;
     }
 
-    let Layout { location, size, .. } = layout.layout(node.up_state.node.unwrap()).unwrap();
+    let Layout { location, size, .. } = layout.layout(node.state.layout.node.unwrap()).unwrap();
 
     let Point { x, y } = location;
     let Size { width, height } = size;
@@ -59,7 +56,7 @@ pub fn render_vnode(
 
             let label = Label {
                 text,
-                style: node.down_state.style,
+                style: node.state.style.style,
             };
             let area = Rect::new(*x as u16, *y as u16, *width as u16, *height as u16);
 
@@ -84,7 +81,7 @@ pub fn render_vnode(
     }
 }
 
-impl RinkWidget for &Node<StretchLayout, StyleModifier> {
+impl RinkWidget for &Node {
     fn render(self, area: Rect, mut buf: RinkBuffer<'_>) {
         use tui::symbols::line::*;
 
@@ -268,14 +265,14 @@ impl RinkWidget for &Node<StretchLayout, StyleModifier> {
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
                 let mut new_cell = RinkCell::default();
-                if let Some(c) = self.down_state.style.bg {
+                if let Some(c) = self.state.style.style.bg {
                     new_cell.bg = c;
                 }
                 buf.set(x, y, new_cell);
             }
         }
 
-        let borders = &self.down_state.modifier.borders;
+        let borders = &self.state.style.modifier.borders;
 
         let last_edge = &borders.left;
         let current_edge = &borders.top;
@@ -292,7 +289,7 @@ impl RinkWidget for &Node<StretchLayout, StyleModifier> {
                 (last_r * RADIUS_MULTIPLIER[0]) as u16,
                 (last_r * RADIUS_MULTIPLIER[1]) as u16,
             ];
-            let color = current_edge.color.or(self.down_state.style.fg);
+            let color = current_edge.color.or(self.state.style.style.fg);
             let mut new_cell = RinkCell::default();
             if let Some(c) = color {
                 new_cell.fg = c;
@@ -327,7 +324,7 @@ impl RinkWidget for &Node<StretchLayout, StyleModifier> {
                 (last_r * RADIUS_MULTIPLIER[0]) as u16,
                 (last_r * RADIUS_MULTIPLIER[1]) as u16,
             ];
-            let color = current_edge.color.or(self.down_state.style.fg);
+            let color = current_edge.color.or(self.state.style.style.fg);
             let mut new_cell = RinkCell::default();
             if let Some(c) = color {
                 new_cell.fg = c;
@@ -362,7 +359,7 @@ impl RinkWidget for &Node<StretchLayout, StyleModifier> {
                 (last_r * RADIUS_MULTIPLIER[0]) as u16,
                 (last_r * RADIUS_MULTIPLIER[1]) as u16,
             ];
-            let color = current_edge.color.or(self.down_state.style.fg);
+            let color = current_edge.color.or(self.state.style.style.fg);
             let mut new_cell = RinkCell::default();
             if let Some(c) = color {
                 new_cell.fg = c;
@@ -397,7 +394,7 @@ impl RinkWidget for &Node<StretchLayout, StyleModifier> {
                 (last_r * RADIUS_MULTIPLIER[0]) as u16,
                 (last_r * RADIUS_MULTIPLIER[1]) as u16,
             ];
-            let color = current_edge.color.or(self.down_state.style.fg);
+            let color = current_edge.color.or(self.state.style.style.fg);
             let mut new_cell = RinkCell::default();
             if let Some(c) = color {
                 new_cell.fg = c;

--- a/packages/tui/src/render.rs
+++ b/packages/tui/src/render.rs
@@ -1,4 +1,3 @@
-use crate::layout::StretchLayout;
 use dioxus_native_core::layout_attributes::UnitSystem;
 use std::io::Stdout;
 use stretch2::{
@@ -12,7 +11,7 @@ use crate::{
     style::{RinkColor, RinkStyle},
     style_attributes::{BorderEdge, BorderStyle},
     widget::{RinkBuffer, RinkCell, RinkWidget, WidgetWithContext},
-    Config, Dom, Node, StyleModifier,
+    Config, Dom, Node,
 };
 
 const RADIUS_MULTIPLIER: [f32; 2] = [1.0, 0.5];

--- a/packages/tui/src/style_attributes.rs
+++ b/packages/tui/src/style_attributes.rs
@@ -29,7 +29,7 @@
 - [ ] pub aspect_ratio: Number,
 */
 
-use dioxus_core::{Attribute, VNode};
+use dioxus_core::Attribute;
 use dioxus_native_core::{
     layout_attributes::{parse_value, UnitSystem},
     state::{AttributeMask, NodeMask, NodeView, ParentDepState},
@@ -49,7 +49,7 @@ impl ParentDepState for StyleModifier {
     // todo: seperate each attribute into it's own class
     const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::All, true, true, false);
 
-    fn reduce(&mut self, node: NodeView, parent: Option<&Self::DepState>, ctx: &Self::Ctx) -> bool {
+    fn reduce(&mut self, node: NodeView, parent: Option<&Self::DepState>, _: &Self::Ctx) -> bool {
         *self = StyleModifier::default();
         if parent.is_some() {
             self.style.fg = None;

--- a/packages/tui/src/style_attributes.rs
+++ b/packages/tui/src/style_attributes.rs
@@ -32,7 +32,7 @@
 use dioxus_core::{Attribute, VNode};
 use dioxus_native_core::{
     layout_attributes::{parse_value, UnitSystem},
-    real_dom::PushedDownState,
+    state::{AttributeMask, NodeMask, NodeView, ParentDepState},
 };
 
 use crate::style::{RinkColor, RinkStyle};
@@ -43,18 +43,22 @@ pub struct StyleModifier {
     pub modifier: TuiModifier,
 }
 
-impl PushedDownState for StyleModifier {
+impl ParentDepState for StyleModifier {
     type Ctx = ();
+    type DepState = Self;
+    // todo: seperate each attribute into it's own class
+    const NODE_MASK: NodeMask = NodeMask::new(AttributeMask::All, true, true, false);
 
-    fn reduce(&mut self, parent: Option<&Self>, vnode: &VNode, _ctx: &mut Self::Ctx) {
+    fn reduce(&mut self, node: NodeView, parent: Option<&Self::DepState>, ctx: &Self::Ctx) -> bool {
         *self = StyleModifier::default();
         if parent.is_some() {
             self.style.fg = None;
         }
-        if let VNode::Element(el) = vnode {
-            // handle text modifier elements
-            if el.namespace.is_none() {
-                match el.tag {
+
+        // handle text modifier elements
+        if node.namespace().is_none() {
+            if let Some(tag) = node.tag() {
+                match tag {
                     "b" => apply_style_attributes("font-weight", "bold", self),
                     "strong" => apply_style_attributes("font-weight", "bold", self),
                     "u" => apply_style_attributes("text-decoration", "underline", self),
@@ -68,11 +72,11 @@ impl PushedDownState for StyleModifier {
                     _ => (),
                 }
             }
+        }
 
-            // gather up all the styles from the attribute list
-            for &Attribute { name, value, .. } in el.attributes {
-                apply_style_attributes(name, value, self);
-            }
+        // gather up all the styles from the attribute list
+        for &Attribute { name, value, .. } in node.attributes() {
+            apply_style_attributes(name, value, self);
         }
 
         // keep the text styling from the parent element
@@ -81,6 +85,7 @@ impl PushedDownState for StyleModifier {
             new_style.bg = self.style.bg;
             self.style = new_style;
         }
+        true
     }
 }
 


### PR DESCRIPTION

The new api:
```rust
use dioxus_native_core::state::*;
use dioxus_native_core_macro::*;

#[derive(State, Default, Clone)]
struct Z {
    // depends on just attributes and no context
    #[node_dep_state()]
    x: A,
    // depends on attributes, the B component of children and i32 context
    #[child_dep_state(B, i32)]
    y: B,
    // depends on attributes, the C component of it's parent and a u8 context
    #[parent_dep_state(C, u8)]
    z: C,
}

use dioxus_native_core::state::NodeDepState;

#[derive(Default, Clone)]
struct A;
impl NodeDepState for A {
    type Ctx = ();
    fn reduce(&mut self, _: NodeView, _: &()) -> bool {
        todo!()
    }
}

#[derive(Default, Clone)]
struct B;
impl ChildDepState for B {
    type Ctx = i32;
    type DepState = Self;
    fn reduce<'a>(
        &mut self,
        _: dioxus_native_core::state::NodeView,
        _: impl Iterator<Item = &'a Self::DepState>,
        _: &i32,
    ) -> bool
    where
        Self::DepState: 'a,
    {
        todo!()
    }
}

#[derive(Default, Clone)]
struct C;
impl ParentDepState for C {
    type Ctx = u8;
    type DepState = Self;
    fn reduce(
        &mut self,
        _: dioxus_native_core::state::NodeView,
        _: Option<&Self::DepState>,
        _: &u8,
    ) -> bool {
        todo!()
    }
}

```